### PR TITLE
Add news entries for DC6 talks at AAAI, IJCAI, NeSy, and XAI

### DIFF
--- a/news.html
+++ b/news.html
@@ -64,6 +64,38 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
       <h1>Latest News</h1>
 
 	<div class="text-and-button">
+		<br>
+		<b>Talk</b> | AAAI 2026 | 22-25 February 2026
+		<h6>
+			DC6 and DC3 delivered an oral presentation of their work <a href="publications.html#pub19"><i>DeepProofLog: Efficient Proving in Deep Stochastic Logic Programs</i></a> at the 40th Annual AAAI Conference on Artificial Intelligence (AAAI 2026) in Singapore.<br>
+		</h6>
+	</div>
+
+	<div class="text-and-button">
+		<br>
+		<b>Talk</b> | IJCAI 2025 | 16-22 August 2025
+		<h6>
+			DC6 delivered an oral presentation of their work <a href="publications.html#pub12"><i>Grounding Methods for Neural-Symbolic AI</i></a> at the 34th International Joint Conference on Artificial Intelligence (IJCAI 2025) in Montreal, Canada.<br>
+		</h6>
+	</div>
+
+	<div class="text-and-button">
+		<br>
+		<b>Talk</b> | NeSy 2025 | 8-10 September 2025
+		<h6>
+			DC6 presented a poster on their work <a href="publications.html#pub11"><i>Distilling KGE black boxes into interpretable NeSy models</i></a> at the 19th International Conference on Neural-Symbolic Learning and Reasoning (NeSy 2025) in Santa Cruz, USA.<br>
+		</h6>
+	</div>
+
+	<div class="text-and-button">
+		<br>
+		<b>Talk</b> | XAI 2025 | 26-28 July 2025
+		<h6>
+			DC6 delivered a talk on their work <a href="publications.html#pub10"><i>Interpretable-by-design Neural-Symbolic Link Prediction on Knowledge Graphs</i></a> at the 3rd World Conference on eXplainable Artificial Intelligence (XAI 2025) in Istanbul, Turkey.<br>
+		</h6>
+	</div>
+
+	<div class="text-and-button">
 	    <br>
   	  <b>DC8 Secondment at University of Bielefeld, Germany</b> | 10 September 2025 – 10 December 2025
   	    <h6>

--- a/news.html
+++ b/news.html
@@ -65,9 +65,46 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 
 	<div class="text-and-button">
 		<br>
-		<b>Talk</b> | AAAI 2026 | 22-25 February 2026
+		<b>Talk</b> | AAAI 2026 | 22-25 January 2026
 		<h6>
 			DC6 and DC3 delivered an oral presentation of their work <a href="publications.html#pub19"><i>DeepProofLog: Efficient Proving in Deep Stochastic Logic Programs</i></a> at the 40th Annual AAAI Conference on Artificial Intelligence (AAAI 2026) in Singapore.<br>
+		</h6>
+	</div>
+
+	<div class="text-and-button">
+	    <br>
+  	  <b>DC8 Secondment at University of Bielefeld, Germany</b> | 10 September 2025 – 10 December 2025
+  	    <h6>
+	        DC8 completed a secondment at the University of Bielefeld, from 10 September 2025 to 10 December 2025.
+   	      During this period, DC8 worked on the post-hoc explainability of neural models applied to Information Retrieval tasks.
+			This secondment initiated the collaboration between two LEMUR partners, UNIMIB and UNIBI, combining different aspects of expertise on LMR approaches.<br>
+	      </h6>
+    </div>
+
+	<div class="text-and-button">
+		<br>
+		<b>Publication</b> | WI-IAT 2025 | 15-18 November 2025
+		<h6>
+			DC8 delivered a presentation of their work <a href="publications.html#pub18"><i>Mixture of Experts Approaches in Dense Retrieval Tasks</i></a> at the
+			24th IEEE/WIC International Conference on Web Intelligence and Intelligent Agent Technology (WI-IAT 2025), which took place in London, United Kingdom,
+      		in November 2025. The paper was presented with the <i>"Best Paper Award"</i>.<br>
+		</h6>
+	</div>
+
+	<div class="text-and-button">
+		<br>
+		<b>Publication</b> | EMNLP 2025 | 4-9 November 2025
+		<h6>
+			DC8 delivered a presentation of their work <a href="publications.html#pub14"><i>Leveraging Cognitive Complexity of Texts for Contextualization in Dense Retrieval</i></a> at the
+			2025 Conference on Empirical Methods in Natural Language Processing (EMNLP 2025), which took place in Suzhou, China, in November 2025.<br>
+		</h6>
+	</div>
+
+	<div class="text-and-button">
+		<br>
+		<b>Poster</b> | NeSy 2025 | 8-10 September 2025
+		<h6>
+			DC6 presented a poster on their work <a href="publications.html#pub11"><i>Distilling KGE black boxes into interpretable NeSy models</i></a> at the 19th International Conference on Neural-Symbolic Learning and Reasoning (NeSy 2025) in Santa Cruz, USA.<br>
 		</h6>
 	</div>
 
@@ -81,49 +118,12 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 
 	<div class="text-and-button">
 		<br>
-		<b>Talk</b> | NeSy 2025 | 8-10 September 2025
-		<h6>
-			DC6 presented a poster on their work <a href="publications.html#pub11"><i>Distilling KGE black boxes into interpretable NeSy models</i></a> at the 19th International Conference on Neural-Symbolic Learning and Reasoning (NeSy 2025) in Santa Cruz, USA.<br>
-		</h6>
-	</div>
-
-	<div class="text-and-button">
-		<br>
 		<b>Talk</b> | XAI 2025 | 26-28 July 2025
 		<h6>
 			DC6 delivered a talk on their work <a href="publications.html#pub10"><i>Interpretable-by-design Neural-Symbolic Link Prediction on Knowledge Graphs</i></a> at the 3rd World Conference on eXplainable Artificial Intelligence (XAI 2025) in Istanbul, Turkey.<br>
 		</h6>
 	</div>
 
-	<div class="text-and-button">
-	    <br>
-  	  <b>DC8 Secondment at University of Bielefeld, Germany</b> | 10 September 2025 – 10 December 2025
-  	    <h6>
-	        DC8 completed a secondment at the University of Bielefeld, from 10 September 2025 to 10 December 2025. 
-   	      During this period, DC8 worked on the post-hoc explainability of neural models applied to Information Retrieval tasks.
-			This secondment initiated the collaboration between two LEMUR partners, UNIMIB and UNIBI, combining different aspects of expertise on LMR approaches.<br>
-	      </h6>
-    </div>
-		
-	<div class="text-and-button">
-		<br>
-		<b>Publication</b> | WI-IAT 2025 | 15-18 November 2025
-		<h6>
-			DC8 delivered a presentation of their work <a href="publications.html#pub18"><i>Mixture of Experts Approaches in Dense Retrieval Tasks</i></a> at the 
-			24th IEEE/WIC International Conference on Web Intelligence and Intelligent Agent Technology (WI-IAT 2025), which took place in London, United Kingdom, 
-      		in November 2025. The paper was presented with the <i>"Best Paper Award"</i>.<br>
-		</h6>
-	</div>
-		
-	<div class="text-and-button">
-		<br>
-		<b>Publication</b> | EMNLP 2025 | 4-9 November 2025
-		<h6>
-			DC8 delivered a presentation of their work <a href="publications.html#pub14"><i>Leveraging Cognitive Complexity of Texts for Contextualization in Dense Retrieval</i></a> at the 
-			2025 Conference on Empirical Methods in Natural Language Processing (EMNLP 2025), which took place in Suzhou, China, in November 2025.<br>
-		</h6>
-	</div>
-		
     <div class="text-and-button">
         <br>
         <b>5th LEMUR Workshop</b> | 2-3 July 2025


### PR DESCRIPTION
## Summary
- Added 4 new news entries for DC6 conference talks/presentations:
  - **AAAI 2026** (Singapore) — Oral presentation of *DeepProofLog* (DC6 & DC3)
  - **IJCAI 2025** (Montreal) — Oral presentation of *Grounding Methods for Neural-Symbolic AI*
  - **NeSy 2025** (Santa Cruz) — Poster on *Distilling KGE black boxes into interpretable NeSy models*
  - **XAI 2025** (Istanbul) — Talk on *Interpretable-by-design Neural-Symbolic Link Prediction on Knowledge Graphs*

## Test plan
- [ ] Verify the new entries render correctly on the news page
- [ ] Verify all publication links point to the correct anchors in publications.html